### PR TITLE
Add "match" and "name" options

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ and automatically re-register any changed or added partials directly with handle
 that can contain the following settings:
 - `precompile`: (default: `false`) If `true`, the partials will be pre-compiled when they are registered.
 - `onchange`: A callback of the form `function(template) {}` that will be called everytime a partial has been changed (added or updated). The name of the partial is passed as the sole parameter.
+- `match`: (default: `/\.(html|hbs)$/`) A regular expression that each partial's filename is tested against to determine whether it is a valid partial.
+- `name`: A function in the form `function(template) {}` that will be called for each partial. The name of the partial is passed as the sole parameter. This function gives you the opportunity to rename the partial before it is registered -- for example, to remove a leading `_` from the filename -- by returning the new name.
 
 `done` is an optional parameter that will be called when the initial registration of partials is complete.
 

--- a/lib/hbs-utils.js
+++ b/lib/hbs-utils.js
@@ -8,8 +8,9 @@ var precompilePartialHelper = function(handlebars, partial) {
 		handlebars.partials[partial] = handlebars.compile(handlebars.partials[partial]);
 	},
 	// Register the partial with handlebars directly
-	registerPartialHelper = function(handlebars, directory, filepath, done) {
-		var isValidTemplate = /\.(html|hbs)$/.test(filepath);
+	registerPartialHelper = function(handlebars, directory, filepath, opts, done) {
+		var regex = (typeof opts.match === 'string') ? new RegExp(opts.match) : opts.match || /\.(html|hbs)$/,
+			isValidTemplate = regex.test(filepath);
 
 		if (!isValidTemplate) {
 			return done(null);
@@ -20,6 +21,7 @@ var precompilePartialHelper = function(handlebars, partial) {
 				var ext = path.extname(filepath);
 				var templateName = path.relative(directory, filepath)
 				.slice(0, -(ext.length)).replace(/[ -]/g, '_');
+				if (typeof opts.name === 'function') templateName = opts.name(templateName);
 				handlebars.registerPartial(templateName, data);
 				return done(undefined, templateName);
 			}
@@ -57,7 +59,7 @@ Instance.prototype.registerPartials = function(directory, opts, done) {
 	// Load all partials in the specified directory
 	walk(directory)
 		.on('file', function(root, stat, next) {
-			registerPartialHelper(handlebars, directory, path.join(root, stat.name), function(err, template) {
+			registerPartialHelper(handlebars, directory, path.join(root, stat.name), opts, function(err, template) {
 				if (opts.precompile && template) precompilePartialHelper(handlebars, template);
 				next(err);
 			});
@@ -80,7 +82,7 @@ Instance.prototype.registerWatchedPartials = function(directory, opts, done) {
 	this.registerPartials(directory, opts, function() {
 		// Now, setup the watcher on the directory
 		watch(directory, function(filename) {
-			registerPartialHelper(handlebars, directory, filename, function(err, template) {
+			registerPartialHelper(handlebars, directory, filename, opts, function(err, template) {
 				if (opts.precompile && template) precompilePartialHelper(handlebars, template);
 				if (opts.onchange && template) opts.onchange(template);
 			});


### PR DESCRIPTION
This pull request makes the regular expression used to check `isValidTemplate` configurable, and adds an option to rename the partial before it's registered.

My partials live amongst other views and are prefixed with an underscore. Unfortunately I can't restructure my template files, so I need a way to limit the registrations to those files with an underscore at the beginning, and have the underscore removed from the name that is registered. 
#### New Options

**`match`**: (default: `/\.(html|hbs)$/`) A regular expression that each partial's filename is tested against to determine whether it is a valid partial.

**`name`**: A function in the form `function(template) {}` that will be called for each partial. The name of the partial is passed as the sole parameter. This function gives you the opportunity to rename the partial before it is registered — for example, to remove a leading `_` from the filename — by returning the new name.
#### Example

``` javascript
var path = require('path');
var hbsutils = require('hbs-utils');

hbsutils.registerPartials('./views', {
  // match html and hbs files beginning with an underscore
  match: /_.+\.(html|hbs)$/,
  // remove the underscore from the partial name
  name: function(template) {
    var basename = path.basename(template);
    return template.replace(basename, basename.replace(/^_/, ''));
  }
});
```
